### PR TITLE
add integresql-client-python to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Our flow now finally changed to this:
 The flow above might look intimidating at first glance, but trust us, it's simple to integrate especially if there is already an client library available for your specific language. We currently have those:
 
 * Go: [integresql-client-go](https://github.com/allaboutapps/integresql-client-go) by [Nick Müller - @MorpheusXAUT](https://github.com/MorpheusXAUT)
+* Python: [integresql-client-python](https://github.com/msztolcman/integresql-client-python) by [Marcin Sztolcman - @msztolcman](https://github.com/msztolcman)
 * ... *Add your link here and make a PR*
 
 #### Integrate by RESTful JSON calls


### PR DESCRIPTION
I've created python version of library for IntegreSQL, and as requested, added link in README :)
BTW, great tool! Thanks!