### PR TITLE
Added EXPOSE to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,3 +86,5 @@ COPY --from=builder-integresql /app/bin/integresql /
 # see https://github.com/GoogleContainerTools/distroless/issues/62
 # and https://github.com/GoogleContainerTools/distroless#entrypoints
 ENTRYPOINT [ "/integresql" ]
+
+EXPOSE 5000


### PR DESCRIPTION
Hey Integresql devs.     
I recently set up Integresql. locally it works great and is exactly what we were looking for.    
But we would also like to use it in our pipelines to automate tests. In our pipeline config we cant set/expose a port without a big change to how they are run.    
By adding the "EXPOSE" in the dockerfile the error that occurs should be fixed seeing as now our pipeline can see a port on the service.

Are there any objections or questions regarding this from your side to merge this?